### PR TITLE
Change chart colours to match table view

### DIFF
--- a/static/charts/chart.js
+++ b/static/charts/chart.js
@@ -11,146 +11,196 @@ window.heatsheet = window.heatsheet || {};
  * @param on
  * @param id
  */
-window.heatsheet.renderChart = function renderChart(temperature, lowHeating, mediumHeating, highHeating, away, off, on, id) {
-    Highcharts.chart(id, {
-        chart: {
-            zoomType: 'x'
+window.heatsheet.renderChart = function renderChart(
+  temperature,
+  lowHeating,
+  mediumHeating,
+  highHeating,
+  away,
+  off,
+  on,
+  id
+) {
+  Highcharts.chart(id, {
+    chart: {
+      zoomType: 'x',
+    },
+    title: {
+      text: '',
+    },
+    time: {
+      useUTC: false,
+    },
+    yAxis: [
+      {
+        labels: {
+          format: '{value} min.',
+          style: {
+            color: Highcharts.getOptions().colors[0],
+          },
         },
         title: {
-            text: ''
+          text: 'Heating times',
+          style: {
+            color: Highcharts.getOptions().colors[0],
+          },
         },
-        time: {
-            useUTC: false
+        opposite: true,
+      },
+      {
+        gridLineWidth: 0,
+        title: {
+          text: 'Temperature',
+          style: {
+            color: '#999999',
+          },
         },
-        yAxis: [
-            {
-                labels: {
-                    format: '{value} min.',
-                    style: {
-                        color: Highcharts.getOptions().colors[0]
-                    }
-                },
-                title: {
-                    text: 'Heating times',
-                    style: {
-                        color: Highcharts.getOptions().colors[0]
-                    }
-                },
-                opposite: true
-            }, {
-                gridLineWidth: 0,
-                title: {
-                    text: 'Temperature',
-                    style: {
-                        color: Highcharts.getOptions().colors[5]
-                    }
-                },
-                labels: {
-                    format: '{value}°C',
-                    style: {
-                        color: Highcharts.getOptions().colors[5]
-                    }
-                }
-
-            },
-            {
-                labels: {
-                    format: '{value} min.',
-                    style: {
-                        color: Highcharts.getOptions().colors[3]
-                    }
-                },
-                title: {
-                    text: 'Heating Modes',
-                    style: {
-                        color: Highcharts.getOptions().colors[3]
-                    }
-                },
-                opposite: true
-            }
-        ],
-        xAxis: {
-            type: 'datetime',
-            crosshair: {
-                snap: false,
-            },
+        labels: {
+          format: '{value}°C',
+          style: {
+            color: '#999999',
+          },
         },
-        plotOptions: {
-            column: {
-                stacking: 'normal'
-            }
+      },
+      {
+        labels: {
+          format: '{value} min.',
+          style: {
+            color: Highcharts.getOptions().colors[3],
+          },
         },
+      },
+    ],
+    xAxis: {
+      type: 'datetime',
+      crosshair: {
+        snap: false,
+      },
+    },
+    plotOptions: {
+      column: {
+        stacking: 'normal',
+      },
+    },
+    tooltip: {
+      shared: true,
+    },
+    series: [
+      {
+        name: 'Temperature',
+        type: 'spline',
+        data: temperature,
+        yAxis: 1,
+        color: '#cccccc',
         tooltip: {
-            shared: true
+          valueSuffix: ' °C',
         },
-        series: [{
-            name: 'Temperature',
-            type: 'spline',
-            data: temperature,
-            yAxis: 1,
-            color: Highcharts.getOptions().colors[5],
-            tooltip: {
-                valueSuffix: ' °C'
-            },
-        }, {
-            name: 'High Heating',
-            type: 'column',
-            yAxis: 0,
-            stack: 1,
-            data: highHeating,
-            tooltip: {
-                valueSuffix: ' min.'
-            },
-        }, {
-            name: 'Medium Heating',
-            type: 'column',
-            yAxis: 0,
-            stack: 1,
-            data: mediumHeating,
-            tooltip: {
-                valueSuffix: ' min.'
-            },
-        }, {
-            name: 'Low Heating',
-            type: 'column',
-            yAxis: 0,
-            stack: 1,
-            data: lowHeating,
-            tooltip: {
-                valueSuffix: ' min.'
-            },
+      },
+      {
+        name: 'High Heating',
+        type: 'column',
+        yAxis: 0,
+        stack: 1,
+        data: highHeating,
+        tooltip: {
+          valueSuffix: ' min.',
         },
-            {
-                name: 'Away Mode',
-                type: 'column',
-                yAxis: 2,
-                stack: 2,
-                data: away,
-                visible: false,
-                tooltip: {
-                    valueSuffix: ' min.'
-                },
-            }, {
-                name: 'Heating off',
-                type: 'column',
-                yAxis: 2,
-                stack: 2,
-                data: off,
-                visible: false,
-                tooltip: {
-                    valueSuffix: ' min.'
-                },
-            }, {
-                name: 'Heating on',
-                type: 'column',
-                yAxis: 2,
-                stack: 2,
-                data: on,
-                visible: false,
-                tooltip: {
-                    valueSuffix: ' min.'
-                },
-            }
-        ]
-    });
+        color: {
+          linearGradient: { x1: 0, x2: 0, y1: 0, y2: 1 },
+          stops: [
+            [0, '#ff3737'], // start
+            [1, '#db2828'], // end
+          ],
+        },
+      },
+      {
+        name: 'Medium Heating',
+        type: 'column',
+        yAxis: 0,
+        stack: 1,
+        data: mediumHeating,
+        tooltip: {
+          valueSuffix: ' min.',
+        },
+        color: {
+          linearGradient: { x1: 0, x2: 0, y1: 0, y2: 1 },
+          stops: [
+            [0, '#ff8c00'], // start
+            [1, '#e07b01'], // end
+          ],
+        },
+      },
+      {
+        name: 'Low Heating',
+        type: 'column',
+        yAxis: 0,
+        stack: 1,
+        data: lowHeating,
+        tooltip: {
+          valueSuffix: ' min.',
+        },
+        color: {
+          linearGradient: { x1: 0, x2: 0, y1: 0, y2: 1 },
+          stops: [
+            [0, '#08b1e3'], // start
+            [1, '#0794be'], // end
+          ],
+        },
+      },
+      {
+        name: 'Away Mode',
+        type: 'column',
+        yAxis: 2,
+        stack: 2,
+        data: away,
+        visible: false,
+        tooltip: {
+          valueSuffix: ' min.',
+        },
+        color: {
+          linearGradient: { x1: 0, x2: 0, y1: 0, y2: 1 },
+          stops: [
+            [0, '#cccccc'], // start
+            [1, '#aaaaaa'], // end
+          ],
+        },
+      },
+      {
+        name: 'Heating off',
+        type: 'column',
+        yAxis: 2,
+        stack: 2,
+        data: off,
+        visible: false,
+        tooltip: {
+          valueSuffix: ' min.',
+        },
+        color: {
+          linearGradient: { x1: 0, x2: 0, y1: 0, y2: 1 },
+          stops: [
+            [0, '#666666'], // start
+            [1, '#444444'], // end
+          ],
+        },
+      },
+      {
+        name: 'Heating on',
+        type: 'column',
+        yAxis: 2,
+        stack: 2,
+        data: on,
+        visible: false,
+        tooltip: {
+          valueSuffix: ' min.',
+        },
+        color: {
+          linearGradient: { x1: 0, x2: 0, y1: 0, y2: 1 },
+          stops: [
+            [0, '#65de3f'], // start
+            [1, '#51b232'], // end
+          ],
+        },
+      },
+    ],
+  });
 };


### PR DESCRIPTION
Hi @orangecoding,

I just tried out the app and it's great. Thank you for putting it together!

I found the colours on the chart a bit confusing, so I updated them to match the table view.

Here's an example:

<img width="1121" alt="Screenshot 2023-11-16 at 09 00 15" src="https://github.com/orangecoding/heatsheet/assets/1211393/f11046a4-293c-48c6-ac33-610470ccf84c">


Feel free to decline this PR, I just thought I'd share.